### PR TITLE
Added option to choose source of the data

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -94,16 +94,16 @@
 			if (this.data.grid.isThemeroller) {
 				this.get_container()
 					.bind("select_node.jstree",$.proxy(function(e,data){
-						data.rslt.obj.children("a").next().addClass("ui-state-active");
+						data.rslt.obj.children("a").nextAll("div").addClass("ui-state-active");
 					},this))
 					.bind("deselect_node.jstree deselect_all.jstree",$.proxy(function(e,data){
-						data.rslt.obj.children("a").next().removeClass("ui-state-active");
+						data.rslt.obj.children("a").nextAll("div").removeClass("ui-state-active");
 					},this))
 					.bind("hover_node.jstree",$.proxy(function(e,data){
-						data.rslt.obj.children("a").next().addClass("ui-state-hover");
+						data.rslt.obj.children("a").nextAll("div").addClass("ui-state-hover");
 					},this))
 					.bind("dehover_node.jstree",$.proxy(function(e,data){
-						data.rslt.obj.children("a").next().removeClass("ui-state-hover");
+						data.rslt.obj.children("a").nextAll("div").removeClass("ui-state-hover");
 					},this));
 			}
 			


### PR DESCRIPTION
Added new option to the configuration of the plugin. Now it is possible to select, what will be the data source for columns. If someone add option "source" to the configuration, and set it's value to "metadata", then, instead of taking data from attributes, it will be taken from data added to node through "metadata" field (as is in jstree documentation). If someone omit the "source" option, or set it to "attr", then plugin will work as before - take data from attributes.
