### PR TITLE
Replace text values with images if needed

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -209,7 +209,7 @@
 
 							// create a span inside the div, so we can control what happens in the whole div versus inside just the text/background
 							span.addClass(cl+" "+valClass).css("display","inline-block").html(content).click(function () {
-								_this.get_container().trigger("select_cell.jstree-grid", [{value: val,column: col.header,node: $(this).closest("li"),sourceName: col.value,sourceType: s}]);
+								$(this).trigger("select_cell.jstree-grid", [{value: val,column: col.header,node: $(this).closest("li"),sourceName: col.value,sourceType: s}]);
 							});
 							last = last.css(conf).css({width: width,"padding-left":paddingleft+"px"}).addClass("jstree-grid-cell "+wcl+ " " + wideValClass + (tr?" ui-state-default":""));
 							


### PR DESCRIPTION
Here's another option for configuration of jstree-grid. This one allows to assign to values paths/urls or classes and then replaces text values with appropriate images. Each column can have separate set of images, there could be a default image or values which not match will be left as text. Example will be best to show this, I suppose.
Here is a fiddle with working example: http://jsfiddle.net/jnwD8/

And here is, how should example configuration looks like:
'grid': {
  columns: [
    {width: 200, header: "Nodes"},
    {
      width: 40,
      header: "rate",
      value: "rate",
      images: {
        1: '_ui-icon ui-icon-star',
        'value with spaces': '_some-class-with-background-set-to-image',
         abc: 'img.png',
         default: 'images/not_rated.png'
      }
    }
  ]

If default image is omited, then not matching values will be left as text.
If user want to set class, then he should start it with "*". It allows to differentiate between classes and filenames (filenames cannot have asterisks in its names).
There is possibility to put more then one class (it is quite common actually when using sprites). In that case the asterisk should be only before first class. There couldn't be any character (including spaces) before the asterisk.
File can be local or remote - user can put [path/]filename.ext or url in config.
