### PR TITLE
Column width calculation

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -26,7 +26,7 @@
 
 	renderAWidth = function(node,tree) {
 		var depth, a = node.get(0).tagName.toLowerCase() === "a" ? node : node.children("a"),
-		width = parseFloat(tree.data.grid.columns[0].width) + parseFloat(tree.data.grid.treeWidthDiff);
+		width = parseInt(tree.data.grid.columns[0].width) + parseInt(tree.data.grid.treeWidthDiff);
 		// need to use a selector in jquery 1.4.4+
 		depth = a.parentsUntil(tree.get_container().get(0).tagName+".jstree").filter("li").length;
 		width = width - depth*18;


### PR DESCRIPTION
Hi, I made a change to column width calculation to be calculated out of float values. I experienced a bug in firefox where columnWidth=250 and treeWidthDiff=0 was resulting in 2500 instead of 250. Values were treated as strings. Thanks for great plugin! 
Cheers, 
Jerry
