### PR TITLE
add explicit "px" measurements to header padding

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -209,7 +209,7 @@
 				borPadWidth = tr ? 1+6 : 2+8; // account for the borders and padding
 				width -= borPadWidth;
 				margin = i === 0 ? 3 : 0;
-				last = $("<div></div>").css(conf).css({"margin-left": margin,"width":width, "padding": "1 3 2 5"}).addClass((tr?"ui-widget-header ":"")+"jstree-grid-header jstree-grid-header-cell jstree-grid-header-"+classAdd+" "+cl).text(val).appendTo(header)
+				last = $("<div></div>").css(conf).css({"margin-left": margin,"width":width, "padding": "1px 3px 2px 5px"}).addClass((tr?"ui-widget-header ":"")+"jstree-grid-header jstree-grid-header-cell jstree-grid-header-"+classAdd+" "+cl).text(val).appendTo(header)
 					.after("<div class='jstree-grid-separator jstree-grid-separator-"+classAdd+(tr ? " ui-widget-header" : "")+(resizable? " jstree-grid-resizable-separator":"")+"'>&nbsp;</div>");
 			}
 			if (last) {


### PR DESCRIPTION
On my system - OSX 10.8, Opera 20/Safari 6.0.1, jQuery 2.1.0 (possibly others, too, but I don't have them available to check) - the specified padding for each header cell div wasn't actually being added at all. My jquery-fu is not strong enough to adequately explain why (I just got started, like, yesterday ;) ), but my best guess is that .css() has some sort of validation check it's doing such that "padding":"1 3 2 5" doesn't pass. Explicitly designating those values as pixel measurements, though, gets it through.
Hope this helps!
