### PR TITLE
Reduce CPU usage on column resize

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -277,8 +277,10 @@
 							if (rightMostLocation + diff > maxMouseX) {
 								diff = 0;
 							}
-							toResize.each(function () { this.style.width = (parseFloat(this.style.width) + diff) + "px"; });
-							oldMouseX = newMouseX;
+							if(diff !== 0){
+								toResize.each(function () { this.style.width = (parseFloat(this.style.width) + diff) + "px"; });
+								oldMouseX = newMouseX;
+							}
 						}
 					});
 			}


### PR DESCRIPTION
Don't calculate and assign width values if the mouse offset hasn't changed.
