### PR TITLE
Hover whole row when mouse moves inside any grid column.

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -593,6 +593,12 @@
 					}
 				};
 			},
+			hoverInHandler = function (node, jsTreeInstance) {
+				return function() { jsTreeInstance.hover_node(node); }
+			},
+			hoverOutHandler = function (node, jsTreeInstance) {
+				return function() { jsTreeInstance.dehover_node(node); }
+			},
 			i, val, cl, wcl, ccl, a, last, valClass, wideValClass, span, paddingleft, title, gridCellName, gridCellParentId, gridCellParent,
 			gridCellPrev, gridCellPrevId, gridCellNext, gridCellNextId, gridCellChild, gridCellChildId, 
 			col, content, tmpWidth, dataRow = this.dataRow, dataCell, lid = objData.id,
@@ -760,6 +766,7 @@
 					// add click handler for clicking inside a grid cell
 					last.click(cellClickHandler(tree,t,val,col,this));
 					last.on("contextmenu",cellRightClickHandler(tree,t,val,col,this));
+					last.hover(hoverInHandler(t, this), hoverOutHandler(t, this));
 					
 					if (title) {
 						span.attr("title",title);


### PR DESCRIPTION
In the base code the row hovered only when mouse enters the column with the jsTree (first usually) and not hovered when mouse enters some of the other columns.
This patch fixes that.