### PR TITLE
don't sort after resize

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -538,6 +538,10 @@
 
 					$(this).closest(".jstree-grid-wrapper").find(".jstree").trigger("resize_column.jstree-grid",[colNum,newPrevColWidth]);
 				})
+				.on("click", ".jstree-grid-separator", function (e) {
+					// don't sort after resize
+					e.stopPropagation();
+				})
 				.on("click", ".jstree-grid-header-cell", function (e) {
 					if (!_this.sort) {
 						return;


### PR DESCRIPTION
Using the resizing handles causes the columns to be sorted onmouseup. This fixes that.