### PR TITLE
Correct demo jstree version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,15 @@ jstree-grid can be made a native component for Angular, Angular2, Polymer, Aurel
 
 ## Usage
 
-1. Include jquery (>= 1.4.2) and jstree in your page, as usual; use jstree v3 or later.
-2. Include jstreegrid.js v3 or later
-3. Include grid as a plugin
-4. Include relevant parameters. 
+1. Include jquery (>= 1.4.2) and jstree in your page, as usual
+2. Inclue jstree **>= 3.3.0**
+3. Include jstreegrid.js v3 or later
+4. Include grid as a plugin
+5. Include relevant parameters.
 
 ````HTML
 <!-- include jstreegrid -->
-<script src="/path/to/jstreegrid.js"></script> 
+<script src="/path/to/jstreegrid.js"></script>
 ````
 
 
@@ -56,7 +57,7 @@ $("div#id").jstree({
 
 As of 3.0.0-beta5, jstree-grid supports AMD, thanks https://github.com/jochenberger
 
-As of 3.1.0-beta1, jstree-grid uses a wrapping table, rather than inserted `div`s in the tree. This does a much better job with widths, alignment, editing, etc. etc. 
+As of 3.1.0-beta1, jstree-grid uses a wrapping table, rather than inserted `div`s in the tree. This does a much better job with widths, alignment, editing, etc. etc.
 
 ### Structure
 
@@ -97,12 +98,12 @@ We use the div to control the entire height and width, and the span to get acces
 
 The reason for both `valueClass` and `wideValueClass` is to give you the ability to control both the narrow part of the text,  and the entire width of the cell. For example, if the cell is 56px wide, but the text in it is "OK" and thus only 20px wide.
 Suppose you have a class "important" which backgrounds in red, and a class "clickable" which changes the cursor to a pointer.
-You want the entire width of the cell to be red, but just the word "OK" to be clickable. 
+You want the entire width of the cell to be red, but just the word "OK" to be clickable.
 You would ensure that "clickable" is applied to the span, but important to the div.
 
 Value is one of:
 
-* the name of the property of the node data whose content will be used; you can choose which once for the entire grid. 
+* the name of the property of the node data whose content will be used; you can choose which once for the entire grid.
 * a function, which will be passed the node's data given by `tree.get_node(node)` for the individual tree item. If you want your custom data, access it via `node.data`
 
 Thus, if you have a node whose data is given by:
@@ -240,11 +241,11 @@ tree.trigger("change_node.jstree",node);
 
 ### HTML
 
-Note that the data in each cell is treated as HTML content for the span, rather than raw text. You can use HTML in any cell, except for the 
+Note that the data in each cell is treated as HTML content for the span, rather than raw text. You can use HTML in any cell, except for the
 base tree node cell, which follows jstree rules.
 
 ### Heights
-The height of the entire div in which the tree is rendered is given by you. If you wish the tree to have a max-height of 40px, you need to set it as part of the standard HTML/CSS. 
+The height of the entire div in which the tree is rendered is given by you. If you wish the tree to have a max-height of 40px, you need to set it as part of the standard HTML/CSS.
 
 ````HTML
 <style>
@@ -270,12 +271,12 @@ The following methods can be called on the jstree:
 
 
 ### Events
-* `loaded.jstree`: When the tree is done loading, as usual, it fires a "loaded.jstree" event on the div to which you added jstree. jsTreeGrid uses this event to start its own load process. 
-* `loaded_grid.jstree`: When jsTreeGrid is done, it fires a "loaded_grid.jstree" event on the same div. If you need to run some 
+* `loaded.jstree`: When the tree is done loading, as usual, it fires a "loaded.jstree" event on the div to which you added jstree. jsTreeGrid uses this event to start its own load process.
+* `loaded_grid.jstree`: When jsTreeGrid is done, it fires a "loaded_grid.jstree" event on the same div. If you need to run some
 code after the jsTreeGrid is done loading, just listen for that event. An example is in the treegrid.HTML sample page.
-* `select_cell.jstree-grid`: If you click in any individual cell, the jstreegrid will fire a "select_cell.jstree_grid" event on the jstree. 
+* `select_cell.jstree-grid`: If you click in any individual cell, the jstreegrid will fire a "select_cell.jstree_grid" event on the jstree.
 * `update_cell.jstree-grid`: If you right-click a cell and edit it, when the edit is complete, and if the value has changed, the jstreegrid will fire a `update_cell.jstree-grid` event on the jstree.
-* `resize_column.jstree-grid`: When a column is resized, whether from dragging the resizer or double-clicking it, this event will be fired. 
+* `resize_column.jstree-grid`: When a column is resized, whether from dragging the resizer or double-clicking it, this event will be fired.
 
 The signature for the select_cell.jstree-grid handler is:
 
@@ -333,7 +334,7 @@ A number of combinations and permutations is possible using the above.
 #### fixed `width` defined for entire grid
 If a fixed `width` is not defined for the entire grid, the behaviour depends on what happens in each column. In all cases, the entire jstree-grid will be the given fixed width.
 
-* If all columns have a fixed width defined, the columns are given those widths. 
+* If all columns have a fixed width defined, the columns are given those widths.
   * If the sum of all columns is *greater* than the width defined on the entire grid, the second column onwards will be inside a scrolling element.
   * If the sum of all columns is *less* than the width defined on the entire grid, the gap will be filled by whitespace after the last column.
 * If one or more columns is defined as `auto`, these will automatically be resized to fill to the entire grid.
@@ -400,7 +401,7 @@ Here are examples:
 #### fixed `width` not defined for entire grid
 If a fixed `width` is not defined for the entire grid, then the grid fills the entire containing element or viewport, i.e. it is treated as `width:100%;`. In that case, the widths of the columns are as follows:
 
-* If all columns have a fixed width defined, the columns are given those widths. 
+* If all columns have a fixed width defined, the columns are given those widths.
   * If the sum of all columns is *greater* than the calculated width of the entire grid, the second column onwards will be inside a scrolling element.
   * If the sum of all columns is *less* than the calculated width of the entire grid, the gap will be filled by whitespace after the last column.
 * If one or more columns is defined as `auto`, these will automatically be resized to fill to the entire grid.
@@ -416,6 +417,3 @@ This section lists significant changes between pre-v3 and v3.
 
 * jstree v3 no longer stores its data in the DOM, rather inside JS. As such, jsTreeGrid no longer stores any data in the DOM. For example, in pre-v3 jstree, `attr` on a node's source data would store the actual data on the DOM as attributes using `jQuery.attr()`. This is no longer true in v3. jsTreeGrid similarly no longer looks for its source data on the DOM. All data to be passed to the grid should be stored in the `data` property of the node's JSON source.
 * `metadata` is no longer an option, since it is no longer necessary to use it to avoid storing data on the DOM.
-
-
-

--- a/tests/chrome-header-test.html
+++ b/tests/chrome-header-test.html
@@ -3,7 +3,7 @@
 		<title>jstree treegrid Chrome resize test</title>
 		<link rel="stylesheet" href="../lib/themes-3/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
-		<script type="text/javascript" src="../lib/jstree-3.0.8.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -49,7 +49,7 @@
 				            {
 				                type: 'document',
 				                text: 'subject page 2',
-                
+
 				                data: {
 				                    hidden: true,
 				                    due_date: '4/8/2015'

--- a/tests/click-sort-test.html
+++ b/tests/click-sort-test.html
@@ -3,7 +3,7 @@
 		<title>jstree treegrid sort test</title>
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/themes/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
-		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/jstree.min.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -11,7 +11,7 @@
 		<script type="text/javascript">
 			$(document).ready(function(){
 				var data;
-				
+
 				data = [{
 					text: "Root 1",
 					data: {price: "$5.00", size: "4",spanclass:"root"},
@@ -22,7 +22,7 @@
 						]}
 					]
 				}];
-				
+
 				$("div#jstree").bind("loaded_grid.jstree",function(){
 					$("span#status").text("loaded");
 				}).on("select_cell.jstree-grid",function (e,data) {
@@ -30,8 +30,8 @@
 				}).on('update_cell.jstree-grid',function (e,data) {
 					$("span#changed").html("changed "+data.col+" from "+data.old+" to "+data.value);
 				});
-				
-				
+
+
 				$("div#jstree").jstree({
 					plugins: ["themes","json","grid","dnd","contextmenu","search","sort"],
 					core: {
@@ -48,27 +48,27 @@
 						contextmenu:true
 					},
 					dnd: {
-            drop_finish : function () { 
-            }, 
-            drag_finish : function () { 
-            }, 
-            drag_check : function (data) { 
-                return { 
-                    after : true, 
-                    before : true, 
-                    inside : true 
-                }; 
-            } 
+            drop_finish : function () {
+            },
+            drag_finish : function () {
+            },
+            drag_check : function (data) {
+                return {
+                    after : true,
+                    before : true,
+                    inside : true
+                };
+            }
 					}
 				});
 				$("a#change").click(function(){
-					var tree = $("div#jstree").jstree(), 
+					var tree = $("div#jstree").jstree(),
 					nodename = tree.get_node("#").children[0], node = tree.get_node(nodename),
 					val = parseInt(node.data.size);
-					
+
 					node.data.size = node.data.size*2;
 					tree.trigger("change_node.jstree",nodename);
-					
+
 					return(false);
 				});
 
@@ -101,6 +101,6 @@
 			<div>Click a cell to see results: <span id="clicked"></span></div>
 			<div>Right-click a cell and edit to see results: <span id="changed"></span></div>
 		</div>
-		
+
 	</body>
 </html>

--- a/tests/dnd-test.html
+++ b/tests/dnd-test.html
@@ -3,7 +3,7 @@
 		<title>jstree treegrid 3.2.0 plugin demo</title>
 		<link rel="stylesheet" href="../lib/themes-3/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
-		<script type="text/javascript" src="../lib/jstree-3.3.0-patched.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -165,15 +165,15 @@
 
 
 		</script>
-			
-			
-			
 
 
 
 
 
-			
+
+
+
+
 	</head>
 	<body>
 

--- a/tests/dynamic-root-node-test.html
+++ b/tests/dynamic-root-node-test.html
@@ -4,7 +4,7 @@
 		<link rel="stylesheet" href="../lib/themes-3/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
 		<script src="http://code.jquery.com/ui/1.10.4/jquery-ui.js"></script>
-		<script type="text/javascript" src="../lib/jstree-3.3.0-patched.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -15,7 +15,7 @@
 
 		    // Will work fine with following added
 		    //var data = [{id:"ded",text:"Works fine",type:"default"}];
-    
+
 		    // This will cause a bug when
 		    var data = [{text:"abc"}],
 		        types = {
@@ -35,7 +35,7 @@
 		                "icon": "glyphicon glyphicon-file",
 		                "valid_children": []
 		            },
-           
+
 		        },
 		        grid = {
 		            columns: [
@@ -94,15 +94,15 @@
 
 		});
 		</script>
-			
-			
-			
 
 
 
 
 
-			
+
+
+
+
 	</head>
 	<body>
 
@@ -131,7 +131,7 @@
 						    </div>
 						    <div>Tree with no nodes (fails)</div>
 						    <div class="mytree" id="tree_bad"></div>
-						</div>  
+						</div>
 
 						<hr/>
 
@@ -142,7 +142,7 @@
 						    </div>
 						    <div>Tree without grid (works)</div>
 						    <div class="mytree" id="tree_only"></div>
-						</div>  
+						</div>
 						</div>
 
 			  </div>

--- a/tests/fixed-widths-resize-test.html
+++ b/tests/fixed-widths-resize-test.html
@@ -3,7 +3,7 @@
 		<title>jstree treegrid 3.2.0 plugin demo</title>
 		<link rel="stylesheet" href="../lib/themes-3/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
-		<script type="text/javascript" src="../lib/jstree-3.0.8.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -11,7 +11,7 @@
 		<script type="text/javascript">
 		$(document).ready(function(){
 				var data;
-				
+
 				data = [{
 					text: "Root 1",
 					data: {price: "$5.00", size: "4",spanclass:"root"},
@@ -22,7 +22,7 @@
 						]}
 					]
 				}];
-				
+
 				$("div#jstree").bind("loaded_grid.jstree",function(){
 					$("span#status").text("loaded");
 				}).on("select_cell.jstree-grid",function (e,data) {
@@ -30,8 +30,8 @@
 				}).on('update_cell.jstree-grid',function (e,data) {
 					$("span#changed").html("changed "+data.col+" from "+data.old+" to "+data.value);
 				});
-				
-				
+
+
 				$("div#jstree").jstree({
 					plugins: ["themes","json","grid"],
 					core: {
@@ -48,7 +48,7 @@
 					}
 				});
 
-	
+
 			});
 		</script>
 	</head>

--- a/tests/fnvalue-test.html
+++ b/tests/fnvalue-test.html
@@ -4,14 +4,14 @@
 		<link rel="stylesheet" href="../lib/themes-3/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
 		<style type="text/css" href="https://www.dropbox.com/s/7u7zirpulyj6vvr/jquery-ui.css?dl=0"></style>
-		<script type="text/javascript" src="../lib/jstree-3.3.0-patched.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<script type="text/javascript">
 			$(document).ready(function(){
-				
+
 				//$( ".stopclick" ).on('click',function( event ) {
 				$( "#wrapper" ).on('click','.stopclick',function( event ) {
-    
+
 				    if (event.preventDefault) {
 				        event.preventDefault();
 				    }
@@ -21,7 +21,7 @@
 				    if (event.stopImmediatePropagation) {
 				        event.stopImmediatePropagation();
 				    }
-				});				
+				});
 				var jsonData = [{
 				    "id": 1,
 				        "text": "Materials and varieties",
@@ -183,6 +183,6 @@
 		<div id="wrapper">
 			<div id="treeViewDiv"></div>
 		</div>
-		
+
 	</body>
 </html>

--- a/tests/grid-api-test.html
+++ b/tests/grid-api-test.html
@@ -5,7 +5,7 @@
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
 		<script type="text/javascript" src="http://code.jquery.com/ui/1.9.2/jquery-ui.js"></script>
 		<link rel="stylesheet" type="text/css" href="http://code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css">
-		<script type="text/javascript" src="../lib/jstree-3.2.1.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<script type="text/javascript">
 			$(document).ready(function(){
@@ -29,7 +29,7 @@
 							    ]
 							 }
 				});
-    
+
 				var to = false;
 				$('#hideCol').click(function () {
 					var ref = $("#jstree").jstree(true)

--- a/tests/odd-named-id-test.html
+++ b/tests/odd-named-id-test.html
@@ -3,7 +3,7 @@
 		<title>jstree treegrid 3.2.0 plugin demo</title>
 		<link rel="stylesheet" href="../lib/themes-3/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
-		<script type="text/javascript" src="../lib/jstree-3.0.8.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -11,7 +11,7 @@
 		<script type="text/javascript">
 		$(document).ready(function(){
 				var data;
-				
+
 				data = [{
 					text: "Root 1",
 					data: {price: "$5.00", size: "4",spanclass:"root"},
@@ -22,7 +22,7 @@
 						]}
 					]
 				}];
-				
+
 				$("div#jstree").bind("loaded_grid.jstree",function(){
 					$("span#status").text("loaded");
 				}).on("select_cell.jstree-grid",function (e,data) {
@@ -30,8 +30,8 @@
 				}).on('update_cell.jstree-grid',function (e,data) {
 					$("span#changed").html("changed "+data.col+" from "+data.old+" to "+data.value);
 				});
-				
-				
+
+
 				$("div#jstree").jstree({
 					plugins: ["themes","json","grid"],
 					core: {
@@ -48,7 +48,7 @@
 					}
 				});
 
-	
+
 			});
 		</script>
 	</head>

--- a/tests/rename-dynamic-node-test.html
+++ b/tests/rename-dynamic-node-test.html
@@ -5,7 +5,7 @@
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
 		<script type="text/javascript" src="http://code.jquery.com/ui/1.9.2/jquery-ui.js"></script>
 		<link rel="stylesheet" type="text/css" href="http://code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css">
-		<script type="text/javascript" src="../lib/jstree-3.2.1.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<script type="text/javascript">
 			$(document).ready(function(){
@@ -27,26 +27,26 @@
 				        ref.edit(sel);
 				    };
 				    function node_delete() {
-       
+
 				        var ref = $('#jstree').jstree(true),
 				            sel = ref.get_selected();
 				        if(!sel.length) { return false; }
 				        ref.delete_node(sel);
 				    };
-    
-    
+
+
 				  $(function () {
-        
+
 				    var data = [{ "id" : "root", "parent" : "#", "text" : "Main page"},
 								{ "id" : "child1", "parent" : "root", "text" : "child1", "data" : { "cid" : "promo-01"}},
 								{ "id" : "child1-1", "parent" : "child1", "text" : "Section", "data" : { "cid" : "promo-02"}},
 								{ "id" : "child2-2", "parent" : "child1", "text" : "child2-2", "data" : { "cid" : "promo-03"}},
 								{ "id" : "child2", "parent" : "root", "text" : "child2", "data" : { "cid" : "promo-04"}},
 								{ "id" : "child3", "parent" : "root", "text" : "child3", "data" : { "cid" : "promo-05"}}]
-   
-    
-                    
-    
+
+
+
+
 				    $("#nodeCreate").click(function(){
 				        node_create();
 				    });
@@ -56,8 +56,8 @@
 				     $("#nodeDelete").click(function(){
 				        node_delete();
 				    });
-    
-    
+
+
 				    $('#jstree').jstree({
 				        "plugins" : [
 				        "contextmenu",
@@ -65,19 +65,19 @@
 				        "state",
 				        "wholerow",
 				        "grid"],
-        
+
 				        "core" : {
 				            "animation" : 0,
 				            "data": data,
 				            "multiple" : true,
-				            "check_callback" : function (op, node, par, pos, more) { 
+				            "check_callback" : function (op, node, par, pos, more) {
 				                              if(op === "delete_node") {
 				                                  if (node.parent === '#') {
 				                                      alert('Cannot delete root node of association list!');
 				                                      return false;
 				                                  }
 				                              }
-                              
+
 				                          },
 				            "themes" : { "stripes" : false, "icons" : false }
 				        },
@@ -91,18 +91,18 @@
 				            "resizable": true
 				        }
 				    });
-    
+
 
 				    $('#jstree').on("changed.jstree", function (e, data) {
 				      console.log(data.selected);
 				    });
-    
+
 				    $('#jstree').bind("dblclick.jstree", function (e,data) {
 				        var node = $(e.target).closest("li");
 				           node_rename(node,data);
 				    });
-    
-    
+
+
 
 				  });
 			});
@@ -125,10 +125,10 @@
         <button type="button" class="btn btn-warning btn-sm" id="nodeRename"><i class="glyphicon glyphicon-pencil"></i> Rename</button>
         <button type="button" class="btn btn-danger btn-sm" id="nodeDelete"><i class="glyphicon glyphicon-remove"></i> Delete</button>
     </div>
-    
+
     <div id="jstree"></div>
-    
-   
+
+
 
 
 

--- a/tests/rename_id_test.html
+++ b/tests/rename_id_test.html
@@ -5,7 +5,7 @@
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
 		<script type="text/javascript" src="http://code.jquery.com/ui/1.9.2/jquery-ui.js"></script>
 		<link rel="stylesheet" type="text/css" href="http://code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css">
-		<script type="text/javascript" src="../lib/jstree-3.2.1.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<script type="text/javascript">
 			$(document).ready(function(){
@@ -34,7 +34,7 @@
 					tree.set_id(node,"abc");
 					tree.rename_node(node,"abc");
 				});
-    
+
 			});
 		</script>
 	</head>

--- a/tests/resize-event-test.html
+++ b/tests/resize-event-test.html
@@ -3,7 +3,7 @@
 		<title>jstree treegrid 3.2.0 plugin demo</title>
 		<link rel="stylesheet" href="../lib/themes-3/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
-		<script type="text/javascript" src="../lib/jstree-3.0.8.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -11,7 +11,7 @@
 		<script type="text/javascript">
 		$(document).ready(function(){
 				var data, trees, i, expected;
-				
+
 				data = [{
 					text: "Root 1",
 					data: {price: "$5.00", size: "4",spanclass:"root"},
@@ -22,7 +22,7 @@
 						]}
 					]
 				}];
-				
+
 				$("#jstree").on("resize_column.jstree-grid",function (e,column,width) {
 					$("#colnum").text(column);
 					$("#size").text(width);
@@ -48,19 +48,19 @@
 						}
 					}
 				);
-				
+
 			});
 
 		</script>
-			
-			
-			
 
 
 
 
 
-			
+
+
+
+
 	</head>
 	<body>
 

--- a/tests/search-test.html
+++ b/tests/search-test.html
@@ -5,7 +5,7 @@
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
 		<script type="text/javascript" src="http://code.jquery.com/ui/1.9.2/jquery-ui.js"></script>
 		<link rel="stylesheet" type="text/css" href="http://code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css">
-		<script type="text/javascript" src="../lib/jstree-3.3.1.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<script type="text/javascript">
@@ -55,7 +55,7 @@
 							    ]
 							 }
 				});
-    
+
 				var to = false;
 				$('#treeSearch').keyup(function () {
 					if(to) { clearTimeout(to); }

--- a/tests/sort-without-resizable-test.html
+++ b/tests/sort-without-resizable-test.html
@@ -3,7 +3,7 @@
 		<title>jstree treegrid sort test</title>
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/themes/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
-		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/jstree.min.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -11,7 +11,7 @@
 		<script type="text/javascript">
 			$(document).ready(function(){
 				var data;
-				
+
 				data = [{
 					text: "Root 1",
 					data: {price: "$5.00", size: "4",spanclass:"root"},
@@ -22,15 +22,15 @@
 						]}
 					]
 				}];
-				
+
 				$("div#jstree").bind("loaded_grid.jstree",function(){
 					$("span#status").text("loaded");
 				});
 				$("div#jstreex").bind("loaded_grid.jstree",function(){
 					$("span#status").text("loaded");
 				});
-				
-				
+
+
 				$("div#jstree").jstree({
 					plugins: ["themes","json","grid","dnd","contextmenu","search","sort"],
 					core: {
@@ -47,17 +47,17 @@
 						contextmenu:true
 					},
 					dnd: {
-            drop_finish : function () { 
-            }, 
-            drag_finish : function () { 
-            }, 
-            drag_check : function (data) { 
-                return { 
-                    after : true, 
-                    before : true, 
-                    inside : true 
-                }; 
-            } 
+            drop_finish : function () {
+            },
+            drag_finish : function () {
+            },
+            drag_check : function (data) {
+                return {
+                    after : true,
+                    before : true,
+                    inside : true
+                };
+            }
 					}
 				});
 
@@ -76,20 +76,20 @@
 						contextmenu:true
 					},
 					dnd: {
-            drop_finish : function () { 
-            }, 
-            drag_finish : function () { 
-            }, 
-            drag_check : function (data) { 
-                return { 
-                    after : true, 
-                    before : true, 
-                    inside : true 
-                }; 
-            } 
+            drop_finish : function () {
+            },
+            drag_finish : function () {
+            },
+            drag_check : function (data) {
+                return {
+                    after : true,
+                    before : true,
+                    inside : true
+                };
+            }
 					}
 				});
-				
+
 			});
 		</script>
 	</head>

--- a/tests/widths-test.html
+++ b/tests/widths-test.html
@@ -3,7 +3,7 @@
 		<title>jstree treegrid 3.2.0 plugin demo</title>
 		<link rel="stylesheet" href="../lib/themes-3/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
-		<script type="text/javascript" src="../lib/jstree-3.0.8.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="../jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -11,7 +11,7 @@
 		<script type="text/javascript">
 		$(document).ready(function(){
 				var data, trees, i, expected;
-				
+
 				data = [{
 					text: "Root 1",
 					data: {price: "$5.00", size: "4",spanclass:"root"},
@@ -22,7 +22,7 @@
 						]}
 					]
 				}];
-				
+
 				trees = [
 					{
 						htmlheader: 'Fixed Width, All Columns Defined, Columns &lt; Width',
@@ -259,7 +259,7 @@
 						}
 					}
 				];
-				
+
 				for (i=0; i<trees.length; i++) {
 					expected = trees[i].grid.width+': '+[trees[i].grid.columns[0].width,trees[i].grid.columns[1].width,trees[i].grid.columns[2].width].join(' ');
 					$("div#alltrees").append('<div class="treesection"><h4>'+trees[i].htmlheader+'</h4><p>Expected '+expected+'</p><p class="actuals"></p><div id="jstree'+i+'"></div></div><hr/>');
@@ -269,7 +269,7 @@
 						midw = wrapper.children("div.jstree-grid-midwrapper"),
 						section = wrapper.closest("div.treesection"),
 						actuals = "Actuals "+wrapper.outerWidth()+": "+[midw.find("div.jstree-grid-column:eq(0)").outerWidth(),midw.find("div.jstree-grid-column:eq(1)").outerWidth(),midw.find("div.jstree-grid-column:eq(2)").outerWidth()].join(' ');
-						
+
 						section.find(".actuals").text(actuals);
 					});
 					$("div#jstree"+i).jstree(trees[i]);
@@ -278,15 +278,15 @@
 
 
 		</script>
-			
-			
-			
 
 
 
 
 
-			
+
+
+
+
 	</head>
 	<body>
 

--- a/treegrid.html
+++ b/treegrid.html
@@ -4,7 +4,7 @@
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/themes/default/style.min.css" />
 		<script type='text/javascript' src='http://code.jquery.com/jquery-2.1.0.js'></script>
 		<script type='text/javascript' src="https://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
-		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/jstree.min.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.2/jstree.min.js"></script>
 		<script type="text/javascript" src="jstreegrid.js"></script>
 		<style type="text/css">
 			@import url('http://getbootstrap.com/dist/css/bootstrap.css');
@@ -12,7 +12,7 @@
 		<script type="text/javascript">
 			$(document).ready(function(){
 				var data;
-				
+
 				data = [{
 					text: "Root 1",
 					data: {price: "$5.00", size: "4",spanclass:"root"},
@@ -23,7 +23,7 @@
 						]}
 					]
 				}];
-				
+
 				$("div#jstree").bind("loaded_grid.jstree",function(){
 					$("span#status").text("loaded");
 				}).on("select_cell.jstree-grid",function (e,data) {
@@ -31,8 +31,8 @@
 				}).on('update_cell.jstree-grid',function (e,data) {
 					$("span#changed").html("changed "+data.col+" from "+data.old+" to "+data.value);
 				});
-				
-				
+
+
 				$("div#jstree").jstree({
 					plugins: ["themes","json","grid","dnd","contextmenu","search","sort"],
 					core: {
@@ -52,30 +52,30 @@
 						height: 100
 					},
 					dnd: {
-						drop_finish : function () { 
-						}, 
-						drag_finish : function () { 
-						}, 
-						drag_check : function (data) { 
-						return { 
-							after : true, 
-							before : true, 
-							inside : true 
-						}; 
-						} 
+						drop_finish : function () {
+						},
+						drag_finish : function () {
+						},
+						drag_check : function (data) {
+						return {
+							after : true,
+							before : true,
+							inside : true
+						};
+						}
 					}
 				})
 				.on('loaded.jstree', function() {
 					$("div#jstree").jstree('open_all');
 				});
 				$("a#change").click(function(){
-					var tree = $("div#jstree").jstree(), 
+					var tree = $("div#jstree").jstree(),
 					nodename = tree.get_node("#").children[0], node = tree.get_node(nodename),
 					val = parseInt(node.data.size);
-					
+
 					node.data.size = node.data.size*2;
 					tree.trigger("change_node.jstree",nodename);
-					
+
 					return(false);
 				});
 
@@ -93,7 +93,7 @@
 					var tree = $("div#jstree").jstree();
 					tree.search($(this).val());
 				});
-				
+
 				// Do the second tree
 				$("div#jstreex").bind("loaded_grid.jstree",function(){
 					$("span#xstatus").text("loaded");
@@ -111,20 +111,20 @@
 						]
 					},
 					dnd: {
-		                drop_finish : function () { 
-		                }, 
-		                drag_finish : function () { 
-		                }, 
-		                drag_check : function (data) { 
-		                    return { 
-		                        after : true, 
-		                        before : true, 
-		                        inside : true 
-		                    }; 
-		                } 
+		                drop_finish : function () {
+		                },
+		                drag_finish : function () {
+		                },
+		                drag_check : function (data) {
+		                    return {
+		                        after : true,
+		                        before : true,
+		                        inside : true
+		                    };
+		                }
 					}
 				});
-				
+
 				$("div#jstreec").bind("loaded_grid.jstree",function () {
 					$("span#cstatus").text("loaded")
 				});
@@ -178,17 +178,17 @@
 						resizable:true
 					},
 					dnd: {
-            drop_finish : function () { 
-            }, 
-            drag_finish : function () { 
-            }, 
-            drag_check : function (data) { 
-                return { 
-                    after : true, 
-                    before : true, 
-                    inside : true 
-                }; 
-            } 
+            drop_finish : function () {
+            },
+            drag_finish : function () {
+            },
+            drag_check : function (data) {
+                return {
+                    after : true,
+                    before : true,
+                    inside : true
+                };
+            }
 					}
 				});
 				$("div#jstree5div").jstree({
@@ -206,17 +206,17 @@
 						contextmenu:true
 					},
 					dnd: {
-            drop_finish : function () { 
-            }, 
-            drag_finish : function () { 
-            }, 
-            drag_check : function (data) { 
-                return { 
-                    after : true, 
-                    before : true, 
-                    inside : true 
-                }; 
-            } 
+            drop_finish : function () {
+            },
+            drag_finish : function () {
+            },
+            drag_check : function (data) {
+                return {
+                    after : true,
+                    before : true,
+                    inside : true
+                };
+            }
 					}
 				});
 			});
@@ -267,6 +267,6 @@
 			<div id="jstree5div" style="max-height: 30px;"></div>
 			<div>Tree grid is <span id="fivestatus">loading</span>.</div>
 		</div>
-		
+
 	</body>
 </html>


### PR DESCRIPTION
Fix version of jstree in demo to 3.3.2, and in all tests.

Additionally, update README.md to indicate that jstree 3.3.0 is minimum version.