### PR TITLE
Ensure grid cells inherit animation

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license:
  *   http://www.opensource.org/licenses/mit-license.php
  * 
- * Works only with jstree version >= 3.0.0
+ * Works only with jstree version >= 3.3.0
  *
  * $Date: 2015-11-29 $
  * $Revision:  3.4.2 $
@@ -534,6 +534,8 @@
 				col = this.midWrapper.children("div.jstree-grid-column-"+i);
 				last = $("<div></div>").css(conf).addClass("jstree-grid-div-"+this.uniq+"-"+i+" "+(tr?"ui-widget-header ":"")+" jstree-grid-header jstree-grid-header-cell jstree-grid-header-"+classAdd+" "+cl+" "+ccl).html(val);
 				last.addClass((tr?"ui-widget-header ":"")+"jstree-grid-header jstree-grid-header-"+classAdd);
+				// ensure grid cells inherit jstree animation
+				last.addClass("jstree-animated");
 				last.prependTo(col);
 				last.attr(COL_DATA_ATTR, name);
 				totalWidth += last.outerWidth();


### PR DESCRIPTION
This only will work once class `.jstree-animated` lands in jstree from master, probably v3.3.3.