### PR TITLE
Select childs by class instead of tag type

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -428,7 +428,7 @@
 				}, this))
 			.on("ready.jstree",$.proxy(function (e,data) {
 				// find the line-height of the first known node
-				var anchorHeight = this.element.find("li a:first").outerHeight(), q,
+				var anchorHeight = this.element.find("[class~='jstree-anchor']:first").outerHeight(), q,
 				cls = this.element.attr("class") || "";
 				$('<style type="text/css">div.jstree-grid-cell-root-'+this.rootid+' {line-height: '+anchorHeight+'px; height: '+anchorHeight+'px;}</style>').appendTo("head");
 

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -114,7 +114,7 @@
 		return(fullWidth);
 	},
 	renderATitle = function(node,t,tree) {
-		var a = node.get(0).tagName.toLowerCase() === "a" ? node : node.children("a"), title, col = tree.settings.grid.columns[0];
+		var a = node.hasClass("jstree-anchor") ? node : node.children("[class~='jstree-anchor']"), title, col = tree.settings.grid.columns[0];
 		// get the title
 		title = "";
 		if (col.title) {
@@ -535,16 +535,16 @@
 			if (this._gridSettings.isThemeroller) {
 				this.element
 					.on("select_node.jstree",$.proxy(function(e,data){
-						data.rslt.obj.children("a").nextAll("div").addClass("ui-state-active");
+						data.rslt.obj.children("[class~='jstree-anchor']").nextAll("div").addClass("ui-state-active");
 					},this))
 					.on("deselect_node.jstree deselect_all.jstree",$.proxy(function(e,data){
-						data.rslt.obj.children("a").nextAll("div").removeClass("ui-state-active");
+						data.rslt.obj.children("[class~='jstree-anchor']").nextAll("div").removeClass("ui-state-active");
 					},this))
 					.on("hover_node.jstree",$.proxy(function(e,data){
-						data.rslt.obj.children("a").nextAll("div").addClass("ui-state-hover");
+						data.rslt.obj.children("[class~='jstree-anchor']").nextAll("div").addClass("ui-state-hover");
 					},this))
 					.on("dehover_node.jstree",$.proxy(function(e,data){
-						data.rslt.obj.children("a").nextAll("div").removeClass("ui-state-hover");
+						data.rslt.obj.children("[class~='jstree-anchor']").nextAll("div").removeClass("ui-state-hover");
 					},this));
 			}
 			
@@ -963,7 +963,7 @@
 			t = $(obj);
 			
 			// find the a children
-			a = t.children("a");
+			a = t.children("[class~='jstree-anchor']");
 			highlightSearch = a.hasClass(SEARCHCLASS);
 			
 			if (a.length === 1) {

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -654,7 +654,7 @@
 						ref = $.jstree.reference(currentTree);
 						cols = ref.settings.grid.columns;
 						headers = toResize.parent().children("div.jstree-grid-column");
-						if (isNaN(colNum) || colNum < 0) { ref._gridSettings.treeWidthDiff = currentTree.find("ins:eq(0)").width() + currentTree.find("a:eq(0)").width() - ref._gridSettings.columns[0].width; }
+						if (isNaN(colNum) || colNum < 0) { ref._gridSettings.treeWidthDiff = currentTree.find("ins:eq(0)").width() + currentTree.find("[class~='jstree-anchor']:eq(0)").width() - ref._gridSettings.columns[0].width; }
 						width = ref._gridSettings.columns[colNum].width = parseFloat(toResize.css("width"));
 						isClickedSep = false;
 						toResize = null;


### PR DESCRIPTION
With the addition of `_create_prototype_node` in jstree, nodes can be of any tag type, as long as they keep the class names.