### PR TITLE
Avoid node selection if default is prevented

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,22 @@ The following methods can be called on the jstree:
 * `loaded.jstree`: When the tree is done loading, as usual, it fires a "loaded.jstree" event on the div to which you added jstree. jsTreeGrid uses this event to start its own load process.
 * `loaded_grid.jstree`: When jsTreeGrid is done, it fires a "loaded_grid.jstree" event on the same div. If you need to run some
 code after the jsTreeGrid is done loading, just listen for that event. An example is in the treegrid.HTML sample page.
-* `select_cell.jstree-grid`: If you click in any individual cell, the jstreegrid will fire a "select_cell.jstree_grid" event on the jstree.
+* `select_cell.jstree-grid`: If you click in any individual cell, the jstreegrid will fire a "select_cell.jstree_grid" event on the jstree. This will select the entire line using jstree internals. If you have input HTML rendered as a cell, this can lead to losing focus of your input. To avoid the selection and so avoiding losing focus of your HTML elements, you can prevent the selection by preventing the event, like this:
+``` js
+mytree.on("select_cell.jstree-grid", function(event, data) {
+    if (/* some logic, if you want */) {
+        event.preventDefault();
+    }
+});
+```
+and if you want to actually select the line without losing focus, you can do it manually:
+``` js
+mytree.on("select_cell.jstree-grid", function(event, data) {
+    event.preventDefault();
+    mytree.jstree("deselect_all");
+    mytree.jstree("select_node", data.node);
+});
+```
 * `update_cell.jstree-grid`: If you right-click a cell and edit it, when the edit is complete, and if the value has changed, the jstreegrid will fire a `update_cell.jstree-grid` event on the jstree.
 * `resize_column.jstree-grid`: When a column is resized, whether from dragging the resizer or double-clicking it, this event will be fired.
 

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -1150,7 +1150,7 @@
 					if (title) {
 						span.attr("title",title);
 					}
-
+					tree.trigger("render_cell.jstree-grid", [{value: val, column: col.header, node: t, sourceName: col.value}]);
 				}		
 				last.addClass("jstree-grid-cell-last"+(tr?" ui-state-default":""));
 				// if there is no width given for the last column, do it via automatic

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -1150,7 +1150,6 @@
 					if (title) {
 						span.attr("title",title);
 					}
-					tree.trigger("render_cell.jstree-grid", [{value: val, column: col.header, node: t, sourceName: col.value}]);
 				}		
 				last.addClass("jstree-grid-cell-last"+(tr?" ui-state-default":""));
 				// if there is no width given for the last column, do it via automatic

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -945,8 +945,11 @@
 			defaultWidth = gs.columnWidth, conf = gs.defaultConf, cellClickHandler = function (tree,node,val,col,t) {
 				return function(e) {
 					//node = tree.find("#"+node.attr("id"));
-					node.children(".jstree-anchor").trigger("click.jstree",e);
-					tree.trigger("select_cell.jstree-grid", [{value: val,column: col.header,node: node,grid:$(this),sourceName: col.value}]);
+					var event = jQuery.Event("select_cell.jstree-grid");
+					tree.trigger(event, [{value: val,column: col.header,node: node,grid:$(this),sourceName: col.value}]);
+					if (!event.isDefaultPrevented()) {
+						node.children(".jstree-anchor").trigger("click.jstree",e);
+					}
 				};
 			}, cellRightClickHandler = function (tree,node,val,col,t) {
 				return function (e) {

--- a/tests/components/select-prevent-test.html
+++ b/tests/components/select-prevent-test.html
@@ -1,0 +1,68 @@
+<script type="text/javascript">
+	$(document).ready(function(){
+		var data, input1, input2, input3;
+
+		input1 = "<input type='text'/>";
+
+		input2 = "<select><option>Option 1</option><option>Option 2</option><option>Option 3</option></select>";
+
+		input3 = "<input type='checkbox'/>";
+
+		data = [{
+			text: "Input 1",
+			icon: false,
+			data: {
+				input: input1,
+				val: "Value 1"
+			}
+		}, {
+			text: "Input 2",
+			icon: false,
+			data: {
+				input: input2,
+				val: "Value 2"
+			}
+		}, {
+			text: "Input 3",
+			icon: false,
+			data: {
+				input: input3,
+				val: "Value 3"
+			}
+		}];
+		$("div#jstree").jstree({
+			plugins: ["grid"],
+			grid: {
+				columns: [{
+					tree: true
+				}, {
+					value: "input"
+				}, {
+					value: "val"
+				}]
+			},
+			core: {
+				data: data,
+				themes: {
+					dots: false
+				}
+			}
+		}).on("select_cell.jstree-grid", function(event, data) {
+			// Gets the node data from the tree
+			var node = $("div#jstree").jstree("get_node", data.node);
+			// Checks if the clicked cell is the html input one
+			if (node.data && node.data.input == data.value) {
+				event.preventDefault();
+				// Optionally select the line when clicked
+				$("div#jstree").jstree("deselect_all").jstree("select_node", data.node);
+			}
+		});
+	});
+
+
+</script>
+
+<h2>Tree Select prevent Test</h2>
+
+<div id="jstree">
+</div>

--- a/tests/test-list.json
+++ b/tests/test-list.json
@@ -13,6 +13,7 @@
 	"resize-event-test.html",
 	"search-test.html",
 	"select-child-test.html",
+	"select-prevent-test.html",
 	"sort-without-resizable-test.html",
 	"widths-test.html"
 ]

--- a/tests/test-master.html
+++ b/tests/test-master.html
@@ -21,7 +21,7 @@
 				});
 				$("div#test-list").on('click','a',function (e) {
 					e.preventDefault();
-					item = $(this).attr("id");
+					var item = $(this).attr("id");
 					$("div#tests").load('components/'+item);
 				});
 			});


### PR DESCRIPTION
I use HTML elements (inputs, dropdowns, checkboxes and such) as cell values. When I click an element, `cellClickHandler` calls `click.jstree` event before `select_cell.jstree-grid` is called, making jstree call `$(e.currentTarget).focus();` to focus the anchor element and so losing the focus on the input element:

![](https://i.imgur.com/ecX6ZHg.gif)

This is a problem because the dropdown or input focus is lost. I can regain the lost focus in the callback, but some things happen:
 - On `select` elements the only way to reopen it is by creating a fake `click` event. This will recall the `cellClickHandler` again, that will call my callback and again call the `click` event, and so on.
 - On text inputs, sometimes the selection or caret position is lost.
 - In short, is not optimal to lose focus and regain it when not needed.

To fix this I've added a check to avoid jstree node selection, if the user wants, by calling `event.preventDefault()`, and do the selection logic on its side if he wants (calling `select_node`, for example).