### PR TITLE
Min and Max width support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ We use the div to control the entire height and width, and the span to get acces
 * `columns`: an array of columns to create, on order. Each entry is an object with the following parameters:
 	* `tree`: boolean, whether the jstree should be placed in this column. Only the first `true` is accepted. If no column is set to `tree:true`, then the first column is used.
 	* `width`: width of the column in pixels. If no width is given, the default is `auto` **except for the last column**. In the last column, if no width is given, it is treated as 'auto' and fills the entire rest of the grid to the right.
-	* `header`: string to use as a header for the column.
+    * `minWidth`: Minimum width of the column when width is set to auto.
+    * `maxWidth`: Maximum width of the column when width is set to auto.
+    * `header`: string to use as a header for the column.
 	* `headerClass`: a CSS class to add to the header cell in this column
 	* `columnClass`: a CSS class to add to the header cell and the column cell
 	* `cellClass`: a CSS class to add to each cell in this column (except for the header) - added to the `<span>`

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -624,7 +624,10 @@
 					width = localStorage['jstree-root-'+rootid+'-column-'+i];
 				else
 					width = cols[i].width || defaultWidth;
-
+				
+				var minWidth = cols[i].minWidth || width;
+				var maxWidth = cols[i].maxWidth || width;
+				
 				// we only deal with borders if width is not auto and not percentages
 				borPadWidth = tr ? 1+6 : 2+8; // account for the borders and padding
 				if (width !== 'auto' && typeof(width) !== "string") {
@@ -641,8 +644,8 @@
 				totalWidth += last.outerWidth();
 				puller = $("<div class='jstree-grid-separator jstree-grid-separator-"+classAdd+(tr ? " ui-widget-header" : "")+(resizable? " jstree-grid-resizable-separator":"")+"'>&nbsp;</div>").appendTo(last);
 				col.width(width);
-				col.css("min-width",width);
-				col.css("max-width",width);
+				col.css("min-width", minWidth);
+				col.css("max-width", maxWidth);
 			}
 
 			last.addClass((tr?"ui-widget-header ":"")+"jstree-grid-header jstree-grid-header-last jstree-grid-header-"+classAdd);


### PR DESCRIPTION
This way we can limit the minimum and maximum column size when width is set to auto, instead of getting ultrasmall/ultrabig columns when data is weird.

This will add support for my issue https://github.com/deitch/jstree-grid/issues/207