### PR TITLE
Faster find grid cell

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -504,7 +504,7 @@
 			},this))
 			.on("search.jstree", $.proxy(function (e, data) {
 				// search sometimes filters, so we need to hide all of the appropriate grid cells as well, and show only the matches
-				var grid = this.gridWrapper, that = this, nodesToShow;
+				var grid = this.gridWrapper, that = this, nodesToShow, startTime = new Date().getTime(), endTime;
 				this.holdingCells = {};
 				if(data.nodes.length) {
 					if(this._data.search.som) {
@@ -527,6 +527,8 @@
 					}
 
 					findDataCell(grid,data.nodes.filter(".jstree-node")).addClass(SEARCHCLASS);
+          endTime = new Date().getTime();
+          this.element.trigger("search-complete.jstree-grid", [{time:endTime-startTime}]);
 				}
 				return true;
 			}, this))

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -44,8 +44,13 @@
 			} else if (ids.length === 0) {
 				ret = from.find("div["+NODE_DATA_ATTR+"='"+ids.id+"']");
 			} else {
-				ret = ids.map(function (i,id) {
-					return from.find("div["+NODE_DATA_ATTR+"='"+id.id+"']");
+				// created a hashtable of the valid IDs
+				var idhash = $.makeArray(ids).reduce(function (total, elm) {
+					total[elm.id] = true;
+					return total;
+				}, {});
+				ret = from.find("div").filter(function (index, elm) {
+					return idhash[$(elm).attr(NODE_DATA_ATTR)];
 				});
 			}
 			return ret;

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -38,7 +38,7 @@
 		findDataCell = function (from,ids) {
 			var ret;
 			if (ids === null || ids === undefined) {
-				ret = [];
+				ret = $();
 			} else if (typeof(ids) === "string") {
 				ret = from.find("div["+NODE_DATA_ATTR+"='"+ids+"']");
 			} else if (ids.length === 0) {

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -35,8 +35,20 @@
 		SEARCHCLASS = "jstree-search",
 	SPECIAL_TITLE = "_DATA_", LEVELINDENT = 24, styled = false, GRIDCELLID_PREFIX = "jsgrid_",GRIDCELLID_POSTFIX = "_col",
 		MINCOLWIDTH = 10,
-		findDataCell = function (from,id) {
-			return from.find("div["+NODE_DATA_ATTR+"='"+id+"']");
+		findDataCell = function (from,ids) {
+			var ret;
+			if (ids === null || ids === undefined) {
+				ret = [];
+			} else if (typeof(ids) === "string") {
+				ret = from.find("div["+NODE_DATA_ATTR+"='"+ids+"']");
+			} else if (ids.length === 0) {
+				ret = from.find("div["+NODE_DATA_ATTR+"='"+ids.id+"']");
+			} else {
+				ret = ids.map(function (i,id) {
+					return from.find("div["+NODE_DATA_ATTR+"='"+id.id+"']");
+				});
+			}
+			return ret;
 		},
 		isClickedSep = false, toResize = null, oldMouseX = 0, newMouseX = 0,
 
@@ -426,9 +438,7 @@
 					if (data.node && data.node.children_d) {
 						removeNodes = removeNodes.concat(data.node.children_d);
 					}
-					for (i=0;i<removeNodes.length;i++) {
-						findDataCell(grid,removeNodes[i]).remove();
-					}
+					findDataCell(grid,removeNodes).remove();
 				}
 			}, this))
 			.on("close_node.jstree",$.proxy(function (e,data) {
@@ -490,9 +500,7 @@
 			.on("deselect_all.jstree",$.proxy(function(node,selected,event){
 				// get all of the ids that were unselected
 				var ids = selected.node || [], i;
-				for (i=0;i<ids.length;i++) {
-					findDataCell(this.gridWrapper,ids[i]).removeClass("jstree-clicked");
-				}
+				findDataCell(this.gridWrapper,ids).removeClass("jstree-clicked");
 			},this))
 			.on("search.jstree", $.proxy(function (e, data) {
 				// search sometimes filters, so we need to hide all of the appropriate grid cells as well, and show only the matches
@@ -518,9 +526,7 @@
 						});
 					}
 
-					data.nodes.filter(".jstree-node").each(function (i,node) {
-						findDataCell(grid,node.id).addClass(SEARCHCLASS);
-					});
+					findDataCell(grid,data.nodes.filter(".jstree-node")).addClass(SEARCHCLASS);
 				}
 				return true;
 			}, this))
@@ -528,9 +534,7 @@
 				// search has been cleared, so we need to show all rows
 				var grid = this.gridWrapper;
 				grid.find('div.jstree-grid-cell').show();
-				data.nodes.filter(".jstree-node").each(function (i,node) {
-					findDataCell(grid,node.id).removeClass(SEARCHCLASS);
-				});
+				findDataCell(grid,data.nodes.filter(".jstree-node")).removeClass(SEARCHCLASS);
 				return true;
 			}, this))
 			.on("copy_node.jstree", function (e, data) {
@@ -815,13 +819,13 @@
 						oldNodes = oldNodes.concat(obj.children_d);
 					}
 					// update id in children
-					for (i=0;i<oldNodes.length;i++) {
-						findDataCell(grid,oldNodes[i])
+					findDataCell(grid,oldNodes)
 						.attr(NODE_DATA_ATTR, obj.id)
-						.attr('id', GRIDCELLID_PREFIX+obj.id+GRIDCELLID_POSTFIX+(i+1))
 						.removeClass(GRIDCELLID_PREFIX+old+GRIDCELLID_POSTFIX)
-						.addClass(GRIDCELLID_PREFIX+obj.id+GRIDCELLID_POSTFIX);
-					}
+						.addClass(GRIDCELLID_PREFIX+obj.id+GRIDCELLID_POSTFIX)
+						.each(function(node,i) {
+							node.attr('id', GRIDCELLID_PREFIX+obj.id+GRIDCELLID_POSTFIX+(i+1));
+						});
 				}
 			}
 			return result;
@@ -829,9 +833,7 @@
 		this._hide_grid = function (node) {
 			var children = node && node.children_d ? node.children_d : [], i;
 			// go through each column, remove all children with the correct ID name
-			for (i=0;i<children.length;i++) {
-				findDataCell(this.gridWrapper,children[i]).remove();
-			}
+			findDataCell(this.gridWrapper,children).remove();
 		};
 		this.holdingCells = {};
 		this.getHoldingCells = function (obj,col,hc) {

--- a/tests/components/large-dataset-test.html
+++ b/tests/components/large-dataset-test.html
@@ -1,0 +1,46 @@
+		<script type="text/javascript">
+			$(document).ready(function(){
+				var data = [{ "id" : "Root", "parent" : "#", "text" : "Root"}], i;
+        for (i=1; i<1000; i++) {
+          var entry = { "id" : "child"+i, "parent" : "Root", "text" : "child"+i, "data" : { "one" : i+" one", "two" : i+" two", "three" : i+" three"}};
+          data.push(entry);
+        }
+
+				$('#jstree').jstree({
+					"core" : { "data" : data },
+					"plugins" : [ "search", "grid" ],
+					"grid" : { columns: [
+									{width: 200, header: "name"},
+									{width: 200, header: "one", value: "one"},
+									{width: 200, header: "two", value: "two"},
+									{width: 200, header: "three", value: "three"}
+							    ]
+							 }
+				});
+
+        $('#gosearch').click(function () {
+					var v = $('#treeSearch').val();
+					$('#jstree').jstree(true).search(v);
+				});
+
+			});
+		</script>
+		<style>
+			.columnSearchFields input {
+			  /*
+			  * some magic numbers. not important for this example.
+			  * they make sure the search boxes in this example are located underneath their respective column
+			  */
+			  width: 175px;
+			  margin: 0 3px;
+			}
+		</style>
+		<h2>Large Data Set Search</h2>
+		<div>
+			Should display how long it takes to perform the search. <b>Will only search when you press the "Search" button.</b>
+		</div>
+<input type="text" id="treeSearch" value="" class="input" style="margin:0em auto 1em auto; padding:4px; border-radius:4px; border:1px solid silver;" />
+<input type="button" id="gosearch" value="Search"></button>
+<hr/>
+<div id="jstree"></div>	</body>
+<hr/>

--- a/tests/components/large-dataset-test.html
+++ b/tests/components/large-dataset-test.html
@@ -17,6 +17,9 @@
 							    ]
 							 }
 				});
+        $("#jstree").on("search-complete.jstree-grid", function (event,params) {
+          $("#timecount").text((params||{}).time);
+        });
 
         $('#gosearch').click(function () {
 					var v = $('#treeSearch').val();
@@ -37,8 +40,12 @@
 		</style>
 		<h2>Large Data Set Search</h2>
 		<div>
-			Should display how long it takes to perform the search. <b>Will only search when you press the "Search" button.</b>
+			Should display how long it takes to perform the search. Note that it does it in a crude fashion using a custom event. For true testing, use a profiler.<p/>
+      <b>Will only search when you press the "Search" button.</b>
 		</div>
+    <div>
+      Time for search: <span id="timecount"></span> milliseconds
+    </div>
 <input type="text" id="treeSearch" value="" class="input" style="margin:0em auto 1em auto; padding:4px; border-radius:4px; border:1px solid silver;" />
 <input type="button" id="gosearch" value="Search"></button>
 <hr/>

--- a/tests/test-list.json
+++ b/tests/test-list.json
@@ -17,5 +17,6 @@
 	"select-prevent-test.html",
 	"render_cell-event-test.html",
 	"sort-without-resizable-test.html",
+	"large-dataset-test.html",
 	"widths-test.html"
 ]


### PR DESCRIPTION
Fixes issue wherein calling `findDataCell()` for many tree nodes leads to many jQuery searches and slow performance.