### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Thus, an entry is likely to look like
 
 We use the div to control the entire height and width, and the span to get access to the actual data itself.
 
-###Options
+### Options
 
 #### The options are as follows:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
