### PR TITLE
Added "main" field to package.json to prevent webpack build crashes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
 	"version": "3.9.3",
 	"url": "https://github.com/deitch/jstree-grid",
 	"author": {"name":"Avi Deitcher","url":"https://github.com/deitch"},
+	"main": "jstreegrid.js",
+	"license": "MIT",
   "contributors": [
     {
       "name": "jochenberger",


### PR DESCRIPTION
Hi Avi,

I've tried to use your lib in our project but it breaks webpack build process. I've investigated and found the reason is lack of "main" field in your package.json, so I've added it.
Also I've added "license":"MIT" as per your readme file, to calm down our license checker ;)