### PR TITLE
Restore focus after _detachColumns() + _reattachColumns()

### DIFF
--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -865,7 +865,7 @@
       // if the columns are not detached, then detach them
       if (this._domManipulation == null) {
         var cols = this._gridSettings.columns || [], treecol = this._gridSettings.treecol, mw = this.midWrapper;
-        this._domManipulation = { id: id, columns: {} };
+        this._domManipulation = { id: id, oldActiveElement: document.activeElement, columns: {} };
         for (var i = 0, len = cols.length; i < len; i++) {
           //if (treecol === i) {
           //  continue;
@@ -887,6 +887,7 @@
           //}
           mw[0].appendChild(this._domManipulation.columns[i]);
         }
+        if (this._domManipulation.oldActiveElement !== document.activeElement) { $(this._domManipulation.oldActiveElement).focus(); }
         this._domManipulation = null;
       }
       return true;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jstreegrid",
   "description": "grid plugin for jstree",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "url": "https://github.com/deitch/jstree-grid",
   "author": {
     "name": "Avi Deitcher",


### PR DESCRIPTION
Previously when _detachColumns() removed the DOM element that currently had the focus (i.e. the document.activeElement), then the focus fell to the <body> of the current document and was left there, preventing keyboard events from being fired. To fix this, I now save the current activeElement and restore it in _reattachColumns().