### PR TITLE
Add a title attribute to the header cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ We use the div to control the entire height and width, and the span to get acces
     * `maxWidth`: Maximum width of the column when width is set to `auto`. Does **not** limit manual column resizing.
     * `header`: string to use as a header for the column.
 	* `headerClass`: a CSS class to add to the header cell in this column
+	* `headerTitle`: a title to add to the header cell in this column, shown as a tooltip
 	* `columnClass`: a CSS class to add to the header cell and the column cell
 	* `cellClass`: a CSS class to add to each cell in this column (except for the header) - added to the `<span>`
 	* `wideCellClass`: a CSS class to add to each cell in this column (except for the header) - added to the `<div>`
@@ -98,6 +99,7 @@ We use the div to control the entire height and width, and the span to get acces
 * `resizable`: true/false if the columns should be resizable. Defaults to false.
 * `draggable`: true/false if the columns should be draggable (requires jQuery UI with sortable plugin). Defaults to false.
 * `stateful`: true/false. If true, then whenever a column width is resized, it will store it in html5 localStorage, if available. Defaults to false.
+* `headerAsTitle`: true/false. If true, the header is used as `headerTitle`. If false, no title is added, but in case the option `headerTitle` is set, a title is added. Defaults to false.
 * `contextmenu`: true/false whether or not a context menu for editing the cells should be shown on right-click. Defaults to false.
 * `gridcontextmenu`: function to create context menu items; see context menu of jstree for format. In addition, if `false` or not set, no special context menu. If `true`, creates a default menu to edit the cell entry.
 * `caseInsensitive`: true/false whether or not the column sort should be case insensitive. Default value is false (the default sort is case sensitive)

--- a/jstreegrid.js
+++ b/jstreegrid.js
@@ -192,6 +192,7 @@
 					resizable : s.resizable,
 					draggable : s.draggable,
 					stateful: s.stateful,
+					headerAsTitle: s.headerAsTitle || false,
 					indent: 0,
 					sortOrder: 'text',
 					sortAsc: true,
@@ -673,6 +674,7 @@
 				cl = cols[i].headerClass || "";
 				ccl = cols[i].columnClass || "";
 				val = cols[i].header || "";
+				headerTitle = cols[i].headerTitle || "";
 				do {
 					coluuid = String(Math.floor(Math.random()*10000));
 				} while(this.colrefs[coluuid] !== undefined);
@@ -700,6 +702,14 @@
 				if (this.settings.core.themes.ellipsis === true){
 				  last.addClass('jstree-grid-ellipsis');
 				}
+
+				// add title and strip out HTML
+				var title = gs.headerAsTitle && !headerTitle ? val : (headerTitle ? headerTitle : "");
+				title = title.replace(htmlstripre, '');
+				if (title) {
+					last.attr("title",title);
+				}
+
 				last.prependTo(col);
 				last.attr(COL_DATA_ATTR, name);
 				totalWidth += last.outerWidth();

--- a/package.json
+++ b/package.json
@@ -59,6 +59,5 @@
   "repository": {
     "type": "git",
     "url": "http://github.com/deitch/jstree-grid.git"
-  },
-  "license": "MIT"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jstreegrid",
   "description": "grid plugin for jstree",
-  "version": "3.9.5",
+  "version": "3.10.0",
   "url": "https://github.com/deitch/jstree-grid",
   "author": {
     "name": "Avi Deitcher",


### PR DESCRIPTION
Asked in #271 this adds a title attribute to the header cell if needed. The option is `headerTitle`.

With the new option `headerAsTitle` of the grid the user is able to configure the behaviour of the `headerTitle`. If set to `true` the header is used as title, if set to `false` no title is used. But the option `headerTitle` for a header forces a title.
